### PR TITLE
chore: add compose file with local PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ lerna-debug.log*
 
 .env*.local
 tmp-changelog.md
-
-pg-data/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ lerna-debug.log*
 
 .env*.local
 tmp-changelog.md
+
+pg-data/

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,4 +8,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=travel
     volumes:
-      - ./pg-data:/var/lib/postgresql/data
+      - pg-data:/var/lib/postgresql/data
+
+volumes:
+  pg-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,3 +7,5 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=travel
+    volumes:
+      - ./pg-data:/var/lib/postgresql/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  database:
+    image: postgres:16
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=travel


### PR DESCRIPTION
This is a very basic compose file to have a local PostgreSQL database on your development machine.

Just run `docker compose up` (use -d option if you want it in the background)

Database will be accessible on port 5432 with user `postgres` password `postgres` and database `travel`